### PR TITLE
根据评论数估计文章浏览量

### DIFF
--- a/components/card.vue
+++ b/components/card.vue
@@ -27,7 +27,7 @@
             d="M1.182 12C2.122 6.88 6.608 3 12 3s9.878 3.88 10.819 9c-.94 5.12-5.427 9-10.819 9s-9.878-3.88-10.818-9M12 17a5 5 0 1 0 0-10a5 5 0 0 0 0 10m0-2a3 3 0 1 1 0-6a3 3 0 0 1 0 6"
           ></path>
         </svg>
-        {{ visited }}
+        {{ estimatedViews }}
       </div>
     </section>
     <section class="info-container">
@@ -58,6 +58,25 @@ const cover = ref<HTMLImageElement | undefined>();
 const { height } = useElementSize(cover);
 const visited = ref(getRandomInt(1, 1000));
 watch(height, () => emits("resize"));
+
+const estimatedViews = computed(() => {
+  // 计算评论数量和文章长度
+  const commentsCount = article.value?.comments?.length ?? 0;
+  const articleLength = article.value?.bodyHTML?.length ?? 0;
+
+  // 基础浏览量基于文章长度，设定一个比例因子
+  const baseMultiplier = 2;
+  const gamma = Math.log(articleLength + 1) * baseMultiplier;
+
+  // 根据文章长度调整评论权重
+  const alphaBase = 1; // 评论的基础权重
+  const alpha = alphaBase + Math.sqrt(articleLength); // 评论权重随文章长度增加
+
+  // 估算浏览量
+  const estimatedViews = Math.round(alpha * commentsCount + gamma);
+
+  return estimatedViews
+});
 </script>
 
 <style scoped lang="less">

--- a/components/popup-article.vue
+++ b/components/popup-article.vue
@@ -47,7 +47,7 @@
                   d="M1.182 12C2.122 6.88 6.608 3 12 3s9.878 3.88 10.819 9c-.94 5.12-5.427 9-10.819 9s-9.878-3.88-10.818-9M12 17a5 5 0 1 0 0-10a5 5 0 0 0 0 10m0-2a3 3 0 1 1 0-6a3 3 0 0 1 0 6"
                 ></path>
               </svg>
-              114514
+              <p>{{articleMetrics.estimatedViews}}</p>
             </div>
           </div>
           <close-btn @click="$emit('close')" />
@@ -55,7 +55,7 @@
         <main>
           <div class="cover">
             <img
-              :src="cover"
+              :src="articleMetrics.cover"
               alt="封面"
               loading="lazy"
               @error="isCoverErr = true"
@@ -171,9 +171,30 @@ watch(article, async () => {
   isCoverErr.value = false;
 });
 const isCoverErr = ref(false);
-const cover = computed(() =>
-  isCoverErr.value ? defaultCover : article.value?.cover ?? defaultCover
-);
+const articleMetrics = computed(() => {
+  // 计算评论数量和文章长度
+  const commentsCount = article.value?.comments?.length ?? 0;
+  const articleLength = article.value?.bodyHTML?.length ?? 0;
+
+  // 基础浏览量基于文章长度，设定一个比例因子
+  const baseMultiplier = 2;
+  const gamma = Math.log(articleLength + 1) * baseMultiplier;
+
+  // 根据文章长度调整评论权重
+  const alphaBase = 1; // 评论的基础权重
+  const alpha = alphaBase + Math.sqrt(articleLength); // 评论权重随文章长度增加
+
+  // 估算浏览量
+  const estimatedViews = Math.round(alpha * commentsCount + gamma);
+
+
+  const cover = isCoverErr.value ? defaultCover : article.value?.cover ?? defaultCover;
+
+  return {
+    estimatedViews,
+    cover,
+  };
+});
 </script>
 
 <style scoped lang="less">


### PR DESCRIPTION
尝试利用文章的长度及该文章的评论数量简单计算该文章的浏览量
由于文章评论是滚动后动态获取所以浏览量会随之变化，同样的，在主页显示的文章浏览量是未计算该文章评论数量的，需要用户点击文章进入详情页获取评论后浏览量才会显示为正确的估计数值，这算是一个bug
本人前端水平不行，这个算法也十分简陋，这个pr只是尝试为显示浏览量提供思路