### PR TITLE
隐藏邮件回复的原邮件体

### DIFF
--- a/components/popup-article.vue
+++ b/components/popup-article.vue
@@ -521,6 +521,11 @@ img {
               right: 0;
             }
 
+            .email-hidden-toggle,
+            .email-hidden-reply{
+              display: none;
+            }
+
             > div {
               flex: 1;
               overflow: hidden;


### PR DESCRIPTION
![图](https://s2.loli.net/2024/08/16/V6OLbq2xhTkSY1E.webp)
隐藏这一长串

其实应该直接定位到节点然后`remove()`的，但有动态加载，却没有现成的过滤器注册机制，加不得