### PR TITLE
解决网页端白屏 | fix: 🐛 通过相对路径限制 js 和 manifest 加载

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -14,7 +14,7 @@
     This is a placeholder for base href that will be replaced by the value of
     the `--base-href` argument provided to `flutter build`.
   -->
-    <base href="$FLUTTER_BASE_HREF" />
+    <base href="/inter-knot/" />
 
     <meta charset="UTF-8" />
     <meta content="IE=Edge" http-equiv="X-UA-Compatible" />


### PR DESCRIPTION
应该是可行的